### PR TITLE
Minor tidyup

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      - name: Install dependencies
-        run: dotnet restore
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release
       - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --verbosity normal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.8"
 services:
-  run-tests:
-    build:
-      context: ./src
+  build-test:
+    container_name: build-test
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1
+    volumes:
+      - ./src:/src
+    command: >
+      bash -c "dotnet build src --configuration Release
+      && dotnet test src --verbosity normal"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-WORKDIR /src
-COPY . .
-ENTRYPOINT ["dotnet", "test"]


### PR DESCRIPTION
Removes DockerFile, as all that is needed can be done in docker-compose
Removes dotnet restore, letting the build and test commands do nuget things automatically